### PR TITLE
Update configure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,10 +9,9 @@ Author: Fernando Miguez <femiguez@iastate.edu>,
 Maintainer: Deepak Jaiswal <djaiswal@illinois.edu>,
     David LeBauer <dlebauer@illinois.edu>,
     Fernando Miguez <femiguez@iastate.edu>
+Requires: devtools
 Imports: lattice, stats
 Suggests: testthat, knitr, roxygen2, data.table
 Enhances: data.table
 VignetteBuilder: knitr
 License: FreeBSD + file LICENSE
-Packaged: 2013-03-29 07:12:38 UTC; djaiswal
-RoxygenNote: 6.0.1

--- a/configure
+++ b/configure
@@ -1,2 +1,2 @@
-R --silent --vanilla -e "roxygen2::roxygenize('.', roclets='rd')"
+R --silent --vanilla -e "devtools::document('.', roclets='rd')"
 

--- a/configure.win
+++ b/configure.win
@@ -1,2 +1,2 @@
-R --silent --vanilla -e "roxygen2::roxygenize('.', roclets='rd')"
+R --silent --vanilla -e "devtools::document('.', roclets='rd')"
 


### PR DESCRIPTION
This fixes #9 by replacing `roxygen2::roxygenize` with `devtools::document` in the configure files.

A more standard workflow would be to delete these files and run roxygenize() or document() whenever documentation is updated and before re-installing the package, and checking in the man/*.Rd files. This would have the added benefits of removing dependencies on these two packages, which are designed to make package development easier rather than be required for locally building the package.