### PR TITLE
Port GitHub workflow actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,7 +7,7 @@
 # time ("workflow_dispatch" in the YAML file).
 
 # The workflow can be run manually from
-# https://github.com/ebimodeling/biocro-dev/actions?query=workflow%3AR-CMD-check.
+# https://github.com/ebimodeling/biocro/actions?query=workflow%3AR-CMD-check.
 # For a manual run, the user can specify different eight yes/no (or
 # y/n) options.  (Note that these input values are case insensitive.)
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -78,8 +78,6 @@ name: R-CMD-check
 
 on:
   push:
-    branches:
-      - master
   workflow_dispatch:
     # When running manually, allow users to customize the run:
     inputs:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,7 +24,7 @@ files to a _different_ repository (namely,
 "ebimodeling/biocro-documentation"); see steps 2 and 6 below.
 
 2. The private key was added as a _secret_ in the
-`ebimodeling/biocro-dev` repository (*this* repository) under the key
+`ebimodeling/biocro` repository (*this* repository) under the key
 `PRIVATE_SSH_KEY`.  (See
 https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository.
 The key name matches the reference `secrets.PRIVATE_SSH_KEY` used in
@@ -44,8 +44,8 @@ https://ebimodeling.github.io/biocro-documentation/.
 
 6. The *public* SSH key was added as a deploy key to the
 "ebimodeling/biocro-documentation" repository under the name "Access
-from biocro-dev action".  (See
+from ebimodeling/biocro actions".  (See
 https://docs.github.com/en/developers/overview/managing-deploy-keys#setup-2.
-The name "Access from biocro-dev action" is for informational purposes
+The name "Access from biocro action" is for informational purposes
 only and has no programmatic significance.)
 

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -136,7 +136,7 @@ jobs:
         cd target
 
         # user.name is somewhat arbitrary but must be provided:
-        git config user.name biocro-dev-action
+        git config user.name biocro-action
         git add .
         git commit -m "generated"
         git push

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -5,7 +5,6 @@ name: Update Documentation
 
 on:
   push:
-    branches: [ master ]
     paths:
     # Include all possible Doxygen source files ...
     - 'src/**.cpp'

--- a/.github/workflows/run_bookdown_and_pkgdown.yml
+++ b/.github/workflows/run_bookdown_and_pkgdown.yml
@@ -4,6 +4,7 @@
 name: Generate pkgdown and bookdown documentation
 
 on:
+  push:
   workflow_dispatch:
     # [no inputs]
 

--- a/.github/workflows/run_bookdown_and_pkgdown.yml
+++ b/.github/workflows/run_bookdown_and_pkgdown.yml
@@ -104,7 +104,7 @@ jobs:
         cd target
 
         # user.name is somewhat arbitrary but must be provided:
-        git config user.name biocro-dev-action
+        git config user.name biocro-action
         git add .
         git commit -m "generated pgkdown and bookdown documentation"
         git push

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## BioCro [![Build Status](https://github.com/ebimodeling/biocro-dev/workflows/R-CMD-check/badge.svg)](https://github.com/ebimodeling/biocro-dev/actions?query=workflow%3AR-CMD-check)
+## BioCro [![Build Status](https://github.com/ebimodeling/biocro/workflows/R-CMD-check/badge.svg)](https://github.com/ebimodeling/biocro/actions?query=workflow%3AR-CMD-check)
 BioCro is a model that predicts plant growth over time given crop-specific parameters and environmental data as input.
 
 It uses models of key physiological and biophysical processes underlying plant growth ([Humphries and Long, 1995]), and has previously been used for predicting biomass yield and leaf area index of switchgrass and miscanthus ([Miguez et al., 2009]).

--- a/developer_documentation/contribution_guidelines.md
+++ b/developer_documentation/contribution_guidelines.md
@@ -3,7 +3,7 @@
 ## Making Changes
 
 ### Discuss first
-* Check the list of [GitHub issues](https://github.com/ebimodeling/biocro-dev/issues)<!-- CHANGE THIS URL WHEN MOVING FROM ebimodeling/biocro-dev TO ebimodeling/biocro!!! --> for a discussion of the issue. If there is not one, create an issue with a description of the problem and your proposed solution.
+* Check the list of [GitHub issues](https://github.com/ebimodeling/biocro/issues) for a discussion of the issue. If there is not one, create an issue with a description of the problem and your proposed solution.
 
  By making changes without discussing it with the group, you risk spending time working on a solution that others may not accept. The members of the group also have diverse backgrounds and likely can give valuable design insights.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,7 @@ of the _R-CMD-check_ workflow every time a BioCro developer pushes
 code to the GitHub _master_ branch.  (Users also have the option to
 trigger this workflow manually by clicking a button on GitHub.)
 Workflow results are viewable on GitHub under [the repository's
-_Actions_ tab](https://github.com/ebimodeling/biocro-dev/actions).
+_Actions_ tab](https://github.com/ebimodeling/biocro/actions).
 
 There are (at least) two scenarios, however, under which you may want
 to run tests manually:


### PR DESCRIPTION
This PR changes all references to `biocro-dev` in the workflows and in the documentation built by the workflows  to `biocro`.  Since all of these references were in documentation, documentation-related links, comments, or portions of code where the name used is arbitrary, these changes were not really necessary to get the GitHub actions working.  What _was_ necessary was to add public and private keys on GitHub to allow this repository's actions to push to `ebimodeling/biocro-documentation`.

The only reference to `biocro-dev` that I did not eliminate was the one in `LICENSE`, since its use there is not related to the workflows in any way and since its use there makes sense, even if it may now be unnecessary.  In any case, changes to `LICENSE`, if needed, should be part of a separate issue and PR.

In addition, I changed all workflows so that they are triggered by a push to any branch.  This was necessary in order to test them (I think), because it seems that workflows on a non-default branch cannot be triggered manually until they have been merged into the default branch.  (I'm not absolutely positive this is true, but in any case, I couldn't figure out how to trigger them manually.)  Since (if I'm not mistaken) workflow runs on public repositories are not time-limited, perhaps this change can be permanent.

All three workflows ran successfully.

This all brings up some issues about the workflows, such as when exactly they _should_ be triggered, whether we want to check all platforms now by default, whether we should now disallow `biocro-dev` to overwrite the documentation at `ebimodeling/biocro-documentation`, and so on.  I will perhaps make a separate issue for these.

The target branch for this PR is `merge-ii`, but if that gets merged into `master` first, the target can be changed to `master`.

