### PR TITLE
Fix issues related to new versions of R and knitr

### DIFF
--- a/src/state_map.h
+++ b/src/state_map.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <set>
 #include <string>
+#include <stdexcept>  // for std::out_of_range
 #include <algorithm>  // for std::sort
 
 /**

--- a/vignettes/a_practical_guide_to_biocro.Rnw
+++ b/vignettes/a_practical_guide_to_biocro.Rnw
@@ -2,13 +2,23 @@
 %\VignettePackage{BioCro}
 %\VignetteEngine{knitr::knitr}
 
-% See
-% https://tex.stackexchange.com/questions/148188/knitr-xcolor-incompatible-color-definition
-% for why this is needed:
-<<preliminary-hooks,include=FALSE,error=TRUE>>=
-knitr::knit_hooks$set(document = function(x) {
-    sub('\\usepackage[]{color}', '\\usepackage[dvipsnames,table]{xcolor}', x, fixed = TRUE)
-})
+% In this document, the `hyperref` latex package requires the `xcolor` package,
+% which causes conflicts with `knitr`. Prior to version 1.39 of `knitr`, `knitr`
+% automatically loaded the `color` package, which introduced incompatible color
+% definitions. Starting with version 1.39, `knitr` loads the `xcolor` package
+% instead, which can cause problems because the default `xcolor` options
+% specified by `knitr` do not match the `xcolor` options required by `hyperref`.
+% See the following pages for more information:
+% - https://tex.stackexchange.com/questions/148188/knitr-xcolor-incompatible-color-definition
+% - https://github.com/yihui/knitr/commit/b31228012419e0365ff33e18ef53fd7be7148e38
+<<solve_latex_color_problems,include=FALSE,error=TRUE>>=
+if (packageVersion('knitr') >= "1.39") {
+  knitr::opts_knit$set(latex.options.xcolor = 'dvipsnames')
+} else {
+  knitr::knit_hooks$set(document = function(x) {
+    sub('\\usepackage[]{color}', '\\usepackage[dvipsnames]{xcolor}', x, fixed = TRUE)
+  })
+}
 @
 
 \documentclass[10pt,letterpaper,oneside]{article}

--- a/vignettes/an_introduction_to_biocro.Rnw
+++ b/vignettes/an_introduction_to_biocro.Rnw
@@ -2,13 +2,18 @@
 %\VignettePackage{BioCro}
 %\VignetteEngine{knitr::knitr}
 
-% See
-% https://tex.stackexchange.com/questions/148188/knitr-xcolor-incompatible-color-definition
-% for why this is needed:
-<<preliminary-hooks,include=FALSE,error=TRUE>>=
-knitr::knit_hooks$set(document = function(x) {
+% Prior to version 1.39 of `knitr`, `knitr` automatically loaded the `color`
+% package, which introduced color definitions that were incompatible with those
+% defined by `xcolor`. Starting with version 1.39, `knitr` automatically loads
+% the `xcolor` package instead. See the following pages for more information:
+% - https://tex.stackexchange.com/questions/148188/knitr-xcolor-incompatible-color-definition
+% - https://github.com/yihui/knitr/commit/b31228012419e0365ff33e18ef53fd7be7148e38
+<<solve_latex_color_problems,include=FALSE,error=TRUE>>=
+if (packageVersion('knitr') < "1.39") {
+  knitr::knit_hooks$set(document = function(x) {
     sub('\\usepackage[]{color}', '\\usepackage{xcolor}', x, fixed = TRUE)
-})
+  })
+}
 @
 
 \documentclass{article}

--- a/vignettes/quantitative_model_comparison.Rnw
+++ b/vignettes/quantitative_model_comparison.Rnw
@@ -2,13 +2,23 @@
 %\VignettePackage{BioCro}
 %\VignetteEngine{knitr::knitr}
 
-% See
-% https://tex.stackexchange.com/questions/148188/knitr-xcolor-incompatible-color-definition
-% for why this is needed:
-<<preliminary-hooks,include=FALSE,error=TRUE>>=
-knitr::knit_hooks$set(document = function(x) {
-    sub('\\usepackage[]{color}', '\\usepackage[dvipsnames,table]{xcolor}', x, fixed = TRUE)
-})
+% In this document, the `hyperref` latex package requires the `xcolor` package,
+% which causes conflicts with `knitr`. Prior to version 1.39 of `knitr`, `knitr`
+% automatically loaded the `color` package, which introduced incompatible color
+% definitions. Starting with version 1.39, `knitr` loads the `xcolor` package
+% instead, which can cause problems because the default `xcolor` options
+% specified by `knitr` do not match the `xcolor` options required by `hyperref`.
+% See the following pages for more information:
+% - https://tex.stackexchange.com/questions/148188/knitr-xcolor-incompatible-color-definition
+% - https://github.com/yihui/knitr/commit/b31228012419e0365ff33e18ef53fd7be7148e38
+<<solve_latex_color_problems,include=FALSE,error=TRUE>>=
+if (packageVersion('knitr') >= "1.39") {
+  knitr::opts_knit$set(latex.options.xcolor = 'dvipsnames')
+} else {
+  knitr::knit_hooks$set(document = function(x) {
+    sub('\\usepackage[]{color}', '\\usepackage[dvipsnames]{xcolor}', x, fixed = TRUE)
+  })
+}
 @
 
 \documentclass[10pt,letterpaper,oneside]{article}


### PR DESCRIPTION
Since the releases of `R` version `4.2.0` and `knitr` version `1.39`, there are a few small changes required to get the package to compile and the vignettes to build.

As a side note, when I ran the `pkgdown` workflow on `main`, the vignettes were not successfully produced (probably because BioCro didn't compile) but the workflow claimed that it had no problems.

As another side note, when I published this branch, three workflows were triggered: the one that runs `R CMD check`, the one that generates `doxygen` documentation, and the one that generates `pkgdown` documentation. I don't think this is the behavior we want. Typically we wouldn't want the documentation for a feature branch to automatically overwrite the documentation for the stable version.