### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,22 @@ There are parameters and modules for soybean (_Glycine max_), miscanthus (_Misca
 - On MacOS, Xcode.
 
 #### Installation steps
-Download the BioCro source code from GitHub, unzip the file, and install from the either the command line or from within R using one of the following sets of commands.
 
-Do one of the sets of instruction below. These assume that the source files are in a directory named "biocro".
+- BioCro can be installed directly from GitHub by typing the following in the R command line: `remotes::install_github('ebimodeling/biocro')`. Note that this method requires the `remotes` R package.
 
-- From the command line
-```
-cd path_to_unzipped_directory
-R CMD INSTALL biocro
-```
+- Another option is to download the BioCro source code from GitHub, unzip the file (if necessary), and install the package using one of the following sets of commands, which both assume that the source files are in a directory named "biocro":
 
-- Or from within R
-```
-setwd('path_to_unzipped_directory')
-install.packages('biocro', repos=NULL, type='SOURCE')
-```
+  - From the command line
+  ```
+  cd path_to_unzipped_directory
+  R CMD INSTALL biocro
+  ```
+
+  - Or from within R
+  ```
+  setwd('path_to_unzipped_directory')
+  install.packages('biocro', repos=NULL, type='SOURCE')
+  ```
 
 ### Making contributions
 Please see the [contribution guidelines](documentation/contribution_guidelines.md) before submitting changes.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ There are parameters and modules for soybean (_Glycine max_), miscanthus (_Misca
 
 #### Installation steps
 
-- BioCro can be installed directly from GitHub by typing the following in the R command line: `remotes::install_github('ebimodeling/biocro')`. Note that this method requires the `remotes` R package.
+- There are several R packages (such as `devtools`, `remotes`, and possibly others) that can be used to install other R packages (including BioCro) directly from GitHub. For example: `devtools::install_github('ebimodeling/biocro')`.
 
-- Another option is to download the BioCro source code from GitHub, unzip the file (if necessary), and install the package using one of the following sets of commands, which both assume that the source files are in a directory named "biocro":
+- Another option that does not require any additional R packages is to download the BioCro source code from GitHub, unzip the file (if necessary), and install the package using one of the following sets of commands, which both assume that the source files are in a directory named "biocro":
 
   - From the command line
   ```


### PR DESCRIPTION
Since this is a public repository, it's now very simple to install BioCro directly from GitHub using `remotes::install_github`, as was pointed out in issue https://github.com/ebimodeling/biocro/issues/24.

I think it makes sense to make this change here rather than on `biocro-dev` since it is only relevant on this repository, and it would be beneficial to get it in place sooner instead of waiting for the next official version to become public.