### PR TITLE
Merge resolution

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,14 +39,14 @@ on:
         description: 'Platform to check'
         type: choice
         options:
-          - R 3.5 on Ubuntu
+          - R 3.6 on Ubuntu
           - R release version on Ubuntu
           - R devel version on Ubuntu
-          - R 3.5 on macOS
+          - R 3.6 on macOS
           - R release version on macOS
-          - R 3.5 on Windows
+          - R 3.6 on Windows
           - R release version on Windows
-        default: R 3.5 on Ubuntu
+        default: R 3.6 on Ubuntu
 
 jobs:
 
@@ -70,11 +70,11 @@ jobs:
           # This filter uses the JMESPath query language to modify the
           # strategy matrix (see https://jmespath.org/).  Note that if
           # the event is anything other than 'workflow_dispatch', the
-          # filter condition is true only when configName is 'R 3.5 on
+          # filter condition is true only when configName is 'R 3.6 on
           # Ubuntu'.
           #
           # For the public version of this repository, the "&&
-          # configName = 'R 3.5 on Ubuntu'" clause will be eliminated
+          # configName = 'R 3.6 on Ubuntu'" clause will be eliminated
           # so that when the event is anything other than
           # 'workflow_dispatch', the filter condition is always true
           # and nothing gets filtered out: all the configurations will
@@ -85,25 +85,25 @@ jobs:
           # matrix.  Thus, if the result of the filter is
           # [
           #   {
-          #     "configName": "R 3.5 on Ubuntu",
+          #     "configName": "R 3.6 on Ubuntu",
           #     "os": "ubuntu-20.04",
-          #     "r": "3.5"
+          #     "r": "3.6"
           #   }
           # ],
           # the actual output will be
           # { "include":
           #     [
           #       {
-          #         "configName": "R 3.5 on Ubuntu",
+          #         "configName": "R 3.6 on Ubuntu",
           #         "os": "ubuntu-20.04",
-          #         "r": "3.5"
+          #         "r": "3.6"
           #       }
           #     ]
           # }.       
           filter:
             '[?configName == `${{ github.event.inputs.platform-to-check }}`
                 || `${{ github.event_name }}` != ''workflow_dispatch''
-                    && configName == ''R 3.5 on Ubuntu'']'
+                    && configName == ''R 3.6 on Ubuntu'']'
 
   # For debugging:
   display_matrix:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,7 +21,7 @@ using the command `ssh-keygen -t rsa -b 4096`.  (Use the `-C` option
 to include a comment.  Use an empty pass-phrase) This key pair is used
 in order to allow a workflow defined in _this_ repository to push
 files to a _different_ repository (namely,
-"ebimodeling/biocro-dev-documentation"); see steps 2 and 6 below.
+"ebimodeling/biocro-documentation"); see steps 2 and 6 below.
 
 2. The private key was added as a _secret_ in the
 `ebimodeling/biocro` repository (*this* repository) under the key
@@ -30,17 +30,17 @@ https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypte
 The key name matches the reference `secrets.PRIVATE_SSH_KEY` used in
 the `document.yml` workflow file.)
 
-3. The "ebimodeling/biocro-dev-documentation" repository was created.
+3. The "ebimodeling/biocro-documentation" repository was created.
 
 4. A README.md file was added to the top-level directory of this new
 repository with (relative) links pointing to the (prospective)
 locations of various versions of the documentation.
 
 5. _GitHub Pages_ was enabled for the
-"ebimodeling/biocro-dev-documentation" repository (see
+"ebimodeling/biocro-documentation" repository (see
 https://pages.github.com/).  This results in the files in this
 repository getting automatically published as a Web site to the URL
-https://ebimodeling.github.io/biocro-dev-documentation/.
+https://ebimodeling.github.io/biocro-documentation/.
 
 6. The *public* SSH key was added as a deploy key to the
 "ebimodeling/biocro-documentation" repository under the name "Access

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,10 +4,10 @@ This workflow, *Update Documentation*, runs Doxygen in various
 configurations on the BioCro C++ Library source code and copies and
 commits the result to the repository given as the value of the
 "PUBLISH_TO" environment variable, currently
-"ebimodeling/biocro-dev-documentation".  That repository is, in turn, set
+"ebimodeling/biocro-documentation".  That repository is, in turn, set
 up to publish to a _GitHub Pages_ Web site at the corresponding
 canonical location (currently,
-https://ebimodeling.github.io/biocro-dev-documentation/).
+https://ebimodeling.github.io/biocro-documentation/).
 
 The workflow runs whenever changes to the C++ source files or the
 files implementing this workflow are checked into the master branch.
@@ -24,7 +24,7 @@ files to a _different_ repository (namely,
 "ebimodeling/biocro-dev-documentation"); see steps 2 and 6 below.
 
 2. The private key was added as a _secret_ in the
-`ebimodeling/biocro-dev` repository (*this* repository) under the key
+`ebimodeling/biocro` repository (*this* repository) under the key
 `PRIVATE_SSH_KEY`.  (See
 https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository.
 The key name matches the reference `secrets.PRIVATE_SSH_KEY` used in
@@ -43,9 +43,9 @@ repository getting automatically published as a Web site to the URL
 https://ebimodeling.github.io/biocro-dev-documentation/.
 
 6. The *public* SSH key was added as a deploy key to the
-"ebimodeling/biocro-dev-documentation" repository under the name "Access
-from ebimodeling/biocro-dev documentation workflow".  (See
+"ebimodeling/biocro-documentation" repository under the name "Access
+from ebimodeling/biocro actions".  (See
 https://docs.github.com/en/developers/overview/managing-deploy-keys#setup-2.
-The name "Access from biocro-dev action" is for informational purposes
+The name "Access from biocro action" is for informational purposes
 only and has no programmatic significance.)
 

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -50,7 +50,7 @@ on:
 
 env:
   # The documentation repository:
-  PUBLISH_TO: "ebimodeling/biocro-dev-documentation"
+  PUBLISH_TO: "ebimodeling/biocro-documentation"
   # Relative path from the GitHub workspace directory to the directory
   # where the documentation repository will be checked out:
   BIOCRO_DOCUMENTATION_ROOT: biocro_documentation_root

--- a/.github/workflows/document_quantities.yml
+++ b/.github/workflows/document_quantities.yml
@@ -9,7 +9,7 @@ on:
       - collect_quantity_info-revised
 
 env:
-  publish-to: "ebimodeling/biocro-dev-documentation"
+  publish-to: "ebimodeling/biocro-documentation"
 
 jobs:
   build:
@@ -111,7 +111,7 @@ jobs:
         cd target
 
         # user.name and user.email are somewhat arbitrary but must be provided:
-        git config user.name biocro-dev-action
+        git config user.name biocro-action
         git config user.email bogus@url.com
         git add .
         git commit -m "updated quantities documentation"

--- a/.github/workflows/strategy_matrix.json
+++ b/.github/workflows/strategy_matrix.json
@@ -1,18 +1,18 @@
 [
     {
-        "configName": "R 3.5 on Windows",
+        "configName": "R 3.6 on Windows",
         "os": "windows-latest",
-        "r": "3.5"
+        "r": "3.6"
     },
     {
-        "configName": "R 3.5 on macOS",
+        "configName": "R 3.6 on macOS",
         "os": "macOS-latest",
-        "r": "3.5"
+        "r": "3.6"
     },
     {
-        "configName": "R 3.5 on Ubuntu",
+        "configName": "R 3.6 on Ubuntu",
         "os": "ubuntu-20.04",
-        "r": "3.5"
+        "r": "3.6"
     },
     {
         "configName": "R release version on Ubuntu",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Authors@R: c(
     person("Boost Organization", role = "cph",
            comment = "Author of included Boost library")
     )
-Depends: R (>= 3.5.0)
+Depends: R (>= 3.6.0)
 Imports:
     stats
 Suggests:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There are parameters and modules for soybean (_Glycine max_), miscanthus (_Misca
 
 ### Installation
 #### Requirements
-- The [R environment](https://cran.r-project.org/) version 3.5.0 or greater.
+- The [R environment](https://cran.r-project.org/) version 3.6.0 or greater.
 - On Windows, a version of [Rtools](https://cran.r-project.org/bin/windows/Rtools/) appropriate for your version of R.
 - On Linux, gcc and g++ version 4.9.3 or greater (consult documentation for your distribution for installation instructions).
 - On MacOS, Xcode.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## BioCro [![Build Status](https://github.com/ebimodeling/biocro-dev/workflows/R-CMD-check/badge.svg)](https://github.com/ebimodeling/biocro-dev/actions?query=workflow%3AR-CMD-check)
+## BioCro [![Build Status](https://github.com/ebimodeling/biocro/workflows/R-CMD-check/badge.svg)](https://github.com/ebimodeling/biocro/actions?query=workflow%3AR-CMD-check)
 BioCro is a model that predicts plant growth over time given crop-specific parameters and environmental data as input.
 
 It uses models of key physiological and biophysical processes underlying plant growth ([Humphries and Long, 1995]), and has previously been used for predicting biomass yield and leaf area index of switchgrass and miscanthus ([Miguez et al., 2009]).

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There are parameters and modules for soybean (_Glycine max_), miscanthus (_Misca
       dropdown on the GitHub page for this repository.
    2. Alternatively, clone the repository using Git on the command
       line in the usual fashion by running
-      `git clone <https://github.com/ebimodeling/biocro-dev>` The repository
+      `git clone <https://github.com/ebimodeling/biocro>` The repository
       contains a Git submodule, so you will need to take the additional step of
       running `git submodule update --init` to obtain it.
 2. Install the BioCro R package using one of the following sets of comands.
@@ -62,13 +62,13 @@ There are parameters and modules for soybean (_Glycine max_), miscanthus (_Misca
 ### Making contributions
 
 Please see the [contribution
-guidelines](https://ebimodeling.github.io/biocro-dev-documentation/master/bookdown/contributing-to-biocro.html)
+guidelines](https://ebimodeling.github.io/biocro-documentation/master/bookdown/contributing-to-biocro.html)
 before submitting changes.
 
 ### Software Documentation
 
 See the [BioCro Documentation Web
-Site](https://ebimodeling.github.io/biocro-dev-documentation/master/pkgdown/index.html).  There
+Site](https://ebimodeling.github.io/biocro-documentation/master/pkgdown/index.html).  There
 will be found not only the standard package documentation, but also
 documentation of the C++ code, including notes on the biological
 models used in BioCro and their implementation.  Also included is
@@ -76,7 +76,7 @@ documentation for BioCro package developers and maintainers.
 
 There is also a separate [page that documents all of the quantities
 used by the Standard BioCro Module
-Library](https://ebimodeling.github.io/biocro-dev-documentation/quantity_docs/quantities.html).
+Library](https://ebimodeling.github.io/biocro-documentation/quantity_docs/quantities.html).
 
 ### License
 

--- a/bookdown/book_source/generating_documentation.md
+++ b/bookdown/book_source/generating_documentation.md
@@ -1,9 +1,9 @@
 <!--  external references -->
 
-[online docs]: https://ebimodeling.github.io/biocro-dev-documentation/
+[online docs]: https://ebimodeling.github.io/biocro-documentation/
   "Online documentation for BioCro (dev version)" {target="_blank"}
 
-[master branch online docs]: https://ebimodeling.github.io/biocro-dev-documentation/master/pkgdown/index.html
+[master branch online docs]: https://ebimodeling.github.io/biocro-documentation/master/pkgdown/index.html
   "Online documentation for BioCro master branch (dev version)" {target="_blank"}
 
 <!-- main text -->
@@ -17,9 +17,9 @@ rarely need to.  That is because the documentation is automatically
 generated for you and made available online!
 
 The documentation landing page at
-[https://ebimodeling.github.io/biocro-dev-documentation/][online docs]
+[https://ebimodeling.github.io/biocro-documentation/][online docs]
 links to up-to-date documentation for the latest version of BioCro on
-the _master_ branch (of the `ebimodeling/biocro-dev` GitHub
+the _master_ branch (of the `ebimodeling/biocro` GitHub
 repository), plus select documentation for versions on other branches.
 
 ## When to generate documentation {#sec:when-to-generate-docs}

--- a/developer_documentation/adding_the_boost_libraries.md
+++ b/developer_documentation/adding_the_boost_libraries.md
@@ -54,8 +54,7 @@ operating systems without it. Hence the need for
 5. Run `R CMD check` and truncate any boost file paths that are flagged as
    exceeding 100 characters. Be sure to update any associated `#include`
    directives that reference these files; otherwise, compilation errors will
-   occur. See [commit 9620b2b994c4dbe0421354cd2c52a82eb170a96](https://github.com/ebimodeling/biocro-dev/pull/422/commits/9620b2b994c4dbe0421354cd2c52a82eb170a967)
-   for an example.
+   occur.
 
 ### Notes for using bcp in Windows
 First, follow the instructions in the "Getting Started on Windows"

--- a/developer_documentation/contribution_guidelines.Rmd
+++ b/developer_documentation/contribution_guidelines.Rmd
@@ -1,6 +1,6 @@
 <!-- This file is raw R Markdown code.  To see this as a
 correctly-rendered web page, visit the online documentation at
-https://ebimodeling.github.io/biocro-dev-documentation/, go to the
+https://ebimodeling.github.io/biocro-documentation/, go to the
 Developer's Manual, and find the chapter on contributing to BioCro.
 -->
 
@@ -8,8 +8,8 @@ Developer's Manual, and find the chapter on contributing to BioCro.
 
 <!-- external references -->
 
-<!-- CHANGE THIS URL WHEN MOVING FROM ebimodeling/biocro-dev TO ebimodeling/biocro!!! -->
-[GitHub issues]: https://github.com/ebimodeling/biocro-dev/issues "Doxygen documentation" {target="_blank"}
+<!-- CHANGE THIS URL WHEN MOVING FROM ebimodeling/biocro TO ebimodeling/biocro!!! -->
+[GitHub issues]: https://github.com/ebimodeling/biocro/issues "Doxygen documentation" {target="_blank"}
 
 [Code dependencies are the devil]: https://www.freecodecamp.org/news/code-dependencies-are-the-devil-35ed28b556d
         "Code dependencies are the devil" {target="_blank"}
@@ -28,15 +28,15 @@ Developer's Manual, and find the chapter on contributing to BioCro.
 
 [Solar Position module]: `r params$biocro_root`/src/module_library/solar_position_michalsky.h "Source code for the Solar Position module" {target="_blank"}
 
-<!-- CHANGE THIS URL WHEN MOVING FROM ebimodeling/biocro-dev TO ebimodeling/biocro!!! -->
-[Solar Position module rendering]: https://ebimodeling.github.io/biocro-dev-documentation/master/doxygen/doxygen_docs_modules_public_members_only/classstandard_b_m_l_1_1solar__position__michalsky.html#details "Documentation of the Solar Position module" {target="_blank"}
+<!-- CHANGE THIS URL WHEN MOVING FROM ebimodeling/biocro TO ebimodeling/biocro!!! -->
+[Solar Position module rendering]: https://ebimodeling.github.io/biocro-documentation/master/doxygen/doxygen_docs_modules_public_members_only/classstandard_b_m_l_1_1solar__position__michalsky.html#details "Documentation of the Solar Position module" {target="_blank"}
 
 [dimensions]: https://en.wikipedia.org/wiki/International_System_of_Quantities#Base_quantities "Quantities and their dimensions (Wikipedia)" {target="_blank"}
 [Doxygen]: https://www.doxygen.nl/manual/docblocks.html "Doxygen manual" {target="_blank"}
 [physical quantity]: https://en.wikipedia.org/wiki/Physical_quantity "Wikipedia's entry on Physical Quantities" {target="_blank"}
 [coherent units]: https://en.wikipedia.org/wiki/Coherence_%28units_of_measurement%29 "Wikipedia's entry on Coherent Units" {target="_blank"}
 [src/parameters.h]: `r params$biocro_root`/src/parameters.h "The BioCro parameters.h file" {target="_blank"}
-[unit tests for modules]: https://ebimodeling.github.io/biocro-dev-documentation/master/pkgdown/articles/an_introduction_to_biocro.pdf "Intro to BioCro vignette" {target="_blank"}
+[unit tests for modules]: https://ebimodeling.github.io/biocro-documentation/master/pkgdown/articles/an_introduction_to_biocro.pdf "Intro to BioCro vignette" {target="_blank"}
 [C++ guidelines]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines "C++ Core Guidelines" {target="_blank"}
 [aspects of coding and design]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#S-naming "C++ Core Guidelines' naming and layout suggestions" {target="_blank"}
 [Google C++ style guide]: https://google.github.io/styleguide/cppguide.html#Formatting "Google's guidelines for formatting C++ code" {target="_blank"}

--- a/developer_documentation/formatting_tools.Rmd
+++ b/developer_documentation/formatting_tools.Rmd
@@ -1,6 +1,6 @@
 <!-- This file is raw R Markdown code.  To see this as a
 correctly-rendered web page, visit the online documentation at
-https://ebimodeling.github.io/biocro-dev-documentation/, go to the
+https://ebimodeling.github.io/biocro-documentation/, go to the
 Developer's Manual, and find the section on formatting tools in the
 chapter on contributing to BioCro.  -->
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,19 +1,19 @@
 <!-- external references -->
 
-[online docs]: https://ebimodeling.github.io/biocro-dev-documentation/
+[online docs]: https://ebimodeling.github.io/biocro-documentation/
   "Online documentation for BioCro (dev version)" {target="_blank"}
 
 [master branch docs URL]:
-https://ebimodeling.github.io/biocro-dev-documentation/master/pkgdown/index.html
+https://ebimodeling.github.io/biocro-documentation/master/pkgdown/index.html
 "Online documentation for the master branch of BioCro (dev version)"
 {target="_blank"}
 
-[biocro-dev auto-document workflows]:
-  https://github.com/ebimodeling/biocro-dev/actions/workflows/automatically-call-document.yml
+[biocro auto-document workflows]:
+  https://github.com/ebimodeling/biocro/actions/workflows/automatically-call-document.yml
   "Documentation workflow runs (automatic)" {target="_blank"}
 
-[biocro-dev documention workflows]:
-  https://github.com/ebimodeling/biocro-dev/actions/workflows/document.yml
+[biocro documention workflows]:
+  https://github.com/ebimodeling/biocro/actions/workflows/document.yml
   "Documentation workflow runs (manual)" {target="_blank"}
 
 [pkgdown]: https://pkgdown.r-lib.org/index.html "The pkgdown web site" {target="_blank"}
@@ -23,7 +23,7 @@ https://ebimodeling.github.io/biocro-dev-documentation/master/pkgdown/index.html
 [^landing_page]: Note that this page does not necessarily contain
 links to all available versions of the documentation: it is generated
 from the file `README.md` at the top level of the
-`ebimodeling/biocro-dev-documentation` GitHub repository, and it must
+`ebimodeling/biocro-documentation` GitHub repository, and it must
 be updated manually to change the links that appear.  See the section
 [_When online documentation is generated_](#sec:generation-triggers)
 for information about the URLs for various generated versions.
@@ -35,13 +35,13 @@ expired, you may have to manually call the workflow to regenerate it.
 the pull request you are interested in.)
 
     Manually-triggered workflow runs may be found at
-[https://github.com/ebimodeling/biocro-dev/actions/workflows/automatically-call-document.yml][biocro-dev
+[https://github.com/ebimodeling/biocro/actions/workflows/automatically-call-document.yml][biocro
 documention workflows]
 
 [^direct_links_to_doxygen_docs]: If you manually generate the Doxygen
 documentation without generating the pkgdown framework, you can access
 the Doxygen documents directly by using URLs of the form
-`https://ebimodeling.github.io/biocro-dev-documentation/<branch
+`https://ebimodeling.github.io/biocro-documentation/<branch
 name>/doxygen/<version>/index.html`, where `<version>` is one of
 `doxygen_docs_complete`, `doxygen_docs_framework`,
 `doxygen_docs_modules`, or `doxygen_docs_modules_public_members_only`.
@@ -50,7 +50,7 @@ name>/doxygen/<version>/index.html`, where `<version>` is one of
 developer (Bookdown) documentation without generating the pkgdown
 framework, you can access the Bookdown book directly by using URLs of
 the form
-`https://ebimodeling.github.io/biocro-dev-documentation/<branch
+`https://ebimodeling.github.io/biocro-documentation/<branch
 name>/bookdown/index.html`.
 
 ## Note about the types of documentation in BioCro {.unnumbered #sec:documenation-types}
@@ -82,13 +82,13 @@ There several categories of documentation for BioCro:
 ## The online documentation {-}
 
 Each of the above categories of documentation is available online at
-[https://ebimodeling.github.io/biocro-dev-documentation/][online
+[https://ebimodeling.github.io/biocro-documentation/][online
 docs], the landing page for various versions of the online
-documentation of the code in the `ebimodeling/biocro-dev`
+documentation of the code in the `ebimodeling/biocro`
 repository.[^landing_page]
 
 **The URL for the latest version of the _master_ branch is
-[https://ebimodeling.github.io/biocro-dev-documentation/master/pkgdown/index.html][master branch docs URL].**
+[https://ebimodeling.github.io/biocro-documentation/master/pkgdown/index.html][master branch docs URL].**
 
 ### When online documentation is generated {- #sec:generation-triggers}
 
@@ -97,14 +97,14 @@ Documentation is automatically generated when
 * The master branch of the repository on GitHub is updated.
 
   This version of the documentation lives at
-  [https://ebimodeling.github.io/biocro-dev-documentation/master/pkgdown/index.html][master
+  [https://ebimodeling.github.io/biocro-documentation/master/pkgdown/index.html][master
   branch online docs].
 
 * A version of the repository's history is tagged, and that tag is
   pushed to the GitHub repository.
 
   Each tagged version's documentation lives at a URL of the form
-  `https://ebimodeling.github.io/biocro-dev-documentation/<tag
+  `https://ebimodeling.github.io/biocro-documentation/<tag
   name>/pkgdown/index.html`.
 
 * A pull request is created or updated.
@@ -112,7 +112,7 @@ Documentation is automatically generated when
   In this case, the documentation is generated and packaged as a Zip
   file available for download but is not deployed online.  To download
   such a file, go to
-  [https://github.com/ebimodeling/biocro-dev/actions/workflows/automatically-call-document.yml][biocro-dev
+  [https://github.com/ebimodeling/biocro/actions/workflows/automatically-call-document.yml][biocro
   auto-document workflows] and find a workflow run corresponding to
   the pull request whose documentation you wish to view.  Click on it,
   and then find the artifact to download near the bottom of the
@@ -127,7 +127,7 @@ various types of BioCro documentation.)
 
 If you choose to deploy the branch documentation, the result will live
 at a URL of the form
-`https://ebimodeling.github.io/biocro-dev-documentation/<branch
+`https://ebimodeling.github.io/biocro-documentation/<branch
 name>/pkgdown/index.html`.
 
 ### The layout of the online documentation {-}

--- a/documentation/script/run_bookdown.R
+++ b/documentation/script/run_bookdown.R
@@ -9,7 +9,7 @@ if (requireNamespace("bookdown", quietly = TRUE)) {
 
         ## This is automatically set to "true" when run by a GitHub action:
         if (Sys.getenv("GITHUB_ACTIONS") == "true") {
-            bookdown::render_book(params = list(biocro_root = "https://github.com/ebimodeling/biocro-dev/tree/master"))
+            bookdown::render_book(params = list(biocro_root = "https://github.com/ebimodeling/biocro/tree/master"))
         } else {
             bookdown::render_book()
         }

--- a/doxygen/generating_the_c++_documentation.Rmd
+++ b/doxygen/generating_the_c++_documentation.Rmd
@@ -1,6 +1,6 @@
 <!-- This file is raw R Markdown code.  To see this as a
 correctly-rendered web page, visit the online documentation at
-https://ebimodeling.github.io/biocro-dev-documentation/, go to the
+https://ebimodeling.github.io/biocro-documentation/, go to the
 Developer's Manual, and find the chapter on generating documentation.
 -->
 
@@ -11,7 +11,7 @@ Developer's Manual, and find the chapter on generating documentation.
 [Doxygen]: https://www.doxygen.nl/index.html "Doxygen home page" {target="_blank"}
 [Doxygen Downloads page]: https://www.doxygen.nl/download.html "Doxygen download page" {target="_blank"}
 [Doxygen Installation page]: https://www.doxygen.nl/manual/install.html "Doxygen installation page" {target="_blank"}
-[on-line version]: https://ebimodeling.github.io/biocro-dev-documentation/master/doxygen/doxygen_docs_complete/index.html
+[on-line version]: https://ebimodeling.github.io/biocro-documentation/master/doxygen/doxygen_docs_complete/index.html
                    "Complete Doxygen documentation" {target="_blank"}
 [doxygen_faq]: https://doxygen.nl/manual/faq.html#faq_cmdline "Configuring Doxygen from the Command Line" {target="_blank"}
 [Configuration section]: https://doxygen.nl/manual/config.html "Configuring Doxygen" {target="_blank"}

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,7 @@ of the _R-CMD-check_ workflow every time a BioCro developer pushes
 code to the GitHub _master_ branch.  (Users also have the option to
 trigger this workflow manually by clicking a button on GitHub.)
 Workflow results are viewable on GitHub under [the repository's
-_Actions_ tab](https://github.com/ebimodeling/biocro-dev/actions).
+_Actions_ tab](https://github.com/ebimodeling/biocro/actions).
 
 There are (at least) two scenarios, however, under which you may want
 to run tests manually:


### PR DESCRIPTION
This PR

1.  resolves conflicts between the merge-iii branch and the main branch, mostly in favor of the former except in cases of references to the repository name;
2. changes references to "biocro-dev" to "biocro", except in one case where the reference is to a pull request in the "ebimodeling/biocro-dev" repository;
3. bumps the minimum required R version from 3.5 to 3.6, both in the DESCRIPTION file, the README.md file, and the workflow files.

(The testthat package's latest release, on Oct. 1, requires R >= 3.6.)